### PR TITLE
Update to MiniAODv2 samples

### DIFF
--- a/config/ttDMPostSelection_MUON_FNAL.xml
+++ b/config/ttDMPostSelection_MUON_FNAL.xml
@@ -6,219 +6,299 @@
   <Library Name="libSUHH2ttDMSemiLeptonic"/>
   <Package Name="SUHH2ttDMSemiLeptonic.par" />
   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
-    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-PromptReco-v3" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-PromptReco-v3.1.root" Lumi="0.0"/>
+    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-05Oct2015-v1" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-05Oct2015-v1.1.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="49360680.4" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-10to50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-10to50.2.root" Lumi="0.0"/>
+    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-PromptReco-v4" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-PromptReco-v4.2.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="74961297.1" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-50.3.root" Lumi="0.0"/>
+    <InputData Lumi="48437390" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-10to50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-10to50.3.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="15302.42" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0100to0200" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0100to0200.4.root" Lumi="0.0"/>
+    <InputData Lumi="74669470" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-50.4.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="18167.30" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0200to0400" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0200to0400.5.root" Lumi="0.0"/>
+    <InputData Lumi="2725655" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0100to0200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0100to0200.5.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="154894.59" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0400to0600" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0400to0600.6.root" Lumi="0.0"/>
+    <InputData Lumi="973937" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0200to0400" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0200to0400.6.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="363191.59" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0600toINFT" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0600toINFT.7.root" Lumi="0.0"/>
+    <InputData Lumi="1067758" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0400to0600" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0400to0600.7.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="291457.1" NEventsMax="-1" Type="MC" Version="MC_ST_s-channel_4f_leptonDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_s-channel_4f_leptonDecays.8.root" Lumi="0.0"/>
+    <InputData Lumi="998912" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0600toINFT" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0600toINFT.8.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6146790.4" NEventsMax="-1" Type="MC" Version="MC_ST_t-channel_4f_leptonDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_t-channel_4f_leptonDecays.9.root" Lumi="0.0"/>
+    <InputData Lumi="291220" NEventsMax="-1" Type="MC" Version="MC_ST_s-channel_4f_leptonDecays" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_ST_s-channel_4f_leptonDecays.9.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="27831.2" NEventsMax="-1" Type="MC" Version="MC_ST_tW_antitop_5f_inclusiveDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_tW_antitop_5f_inclusiveDecays.10.root" Lumi="0.0"/>
+    <InputData Lumi="18895860" NEventsMax="-1" Type="MC" Version="MC_ST_t-channel_4f_leptonDecays" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_ST_t-channel_4f_leptonDecays.10.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="27709.4" NEventsMax="-1" Type="MC" Version="MC_ST_tW_top_5f_inclusiveDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_tW_top_5f_inclusiveDecays.11.root" Lumi="0.0"/>
+    <InputData Lumi="27966.9" NEventsMax="-1" Type="MC" Version="MC_STneg_tW_inc" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_STneg_tW_inc.11.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="113811.0" NEventsMax="-1" Type="MC" Version="MC_TTbar" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbar.12.root" Lumi="0.0"/>
+    <InputData Lumi="27966.3" NEventsMax="-1" Type="MC" Version="MC_STpos_tW_inc" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_STpos_tW_inc.12.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="49294.7" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-700to1000" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-700to1000.13.root" Lumi="0.0"/>
+    <InputData Lumi="45960000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1.13.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="112601.2" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-1000toInf" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-1000toInf.14.root" Lumi="0.0"/>
+    <InputData Lumi="45990000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-10" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-10.14.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="454.5" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-170to300_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-170to300_MuEnrichedPt5.21.root" Lumi="0.0"/>
+    <InputData Lumi="58360000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-100" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-100.15.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="4893.1" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-300to470_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-300to470_MuEnrichedPt5.22.root" Lumi="0.0"/>
+    <InputData Lumi="3815000000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1000" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1000.16.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="24346.6" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-470to600_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-470to600_MuEnrichedPt5.23.root" Lumi="0.0"/>
+    <InputData Lumi="79160000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-200.17.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="78855.4" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-600to800_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-600to800_MuEnrichedPt5.24.root" Lumi="0.0"/>
+    <InputData Lumi="48920000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-50.18.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="420118.0" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-800to1000_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-800to1000_MuEnrichedPt5.25.root" Lumi="0.0"/>
+    <InputData Lumi="315300000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-500.19.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1219588.2" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-1000toInf_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-1000toInf_MuEnrichedPt5.26.root" Lumi="0.0"/>
+    <InputData Lumi="505800000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-600" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-600.20.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="45901773930" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1.27.root" Lumi="0.0"/>
+    <InputData Lumi="3186000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10.21.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="57301200370" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-100.28.root" Lumi="0.0"/>
+    <InputData Lumi="250000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100.22.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="77601515550" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-200.29.root" Lumi="0.0"/>
+    <InputData Lumi="163100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50.23.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="3250197" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10.30.root" Lumi="0.0"/>
+    <InputData Lumi="151200000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-1000" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-1000.24.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="250344.1" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100.31.root" Lumi="0.0"/>
+    <InputData Lumi="127300000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200.25.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="163325.8" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50.32.root" Lumi="0.0"/>
+    <InputData Lumi="11220000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-500.26.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="127494310" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200.33.root" Lumi="0.0"/>
+    <InputData Lumi="112238" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10.27.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="112382" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10.34.root" Lumi="0.0"/>
+    <InputData Lumi="260373" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100.28.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="260709.1" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100.35.root" Lumi="0.0"/>
+    <InputData Lumi="121100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-20" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-20.29.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1266911.4" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300.36.root" Lumi="0.0"/>
+    <InputData Lumi="553100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-200.30.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="17922176310" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500.37.root" Lumi="0.0"/>
+    <InputData Lumi="1265000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300.31.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1671503.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300.38.root" Lumi="0.0"/>
+    <InputData Lumi="165200" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-50.32.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="19144916.2" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50.39.root" Lumi="0.0"/>
+    <InputData Lumi="9620000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-500.33.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="494648.9" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-10.40.root" Lumi="0.0"/>
+    <InputData Lumi="17890000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500.34.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="66370.5" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-100.41.root" Lumi="0.0"/>
+    <InputData Lumi="588200" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-200.35.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="16350.3" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-50.42.root" Lumi="0.0"/>
+    <InputData Lumi="1328000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300.36.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="158066801.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-1000" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-1000.43.root" Lumi="0.0"/>
+    <InputData Lumi="17260000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50.37.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="12917746.5" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-500.44.root" Lumi="0.0"/>
+    <InputData Lumi="494100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-10" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-10.38.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="71303.3" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-100.45.root" Lumi="0.0"/>
+    <InputData Lumi="66290" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-100" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-100.39.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="16457.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-50.46.root" Lumi="0.0"/>
+    <InputData Lumi="16330" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-50.40.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1671503.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-300.47.root" Lumi="0.0"/>
+    <InputData Lumi="363800000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-200.41.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="19144916.2" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-50.48.root" Lumi="0.0"/>
+    <InputData Lumi="2262" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-10" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-10.42.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="60501928.3" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu.49.root" Lumi="0.0"/>
+    <InputData Lumi="71210" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-100" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-100.43.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6099.987" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT100To200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT100To200.50.root" Lumi="0.0"/>
+    <InputData Lumi="152300000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-1000" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-1000.44.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="12010.68" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT200To400" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT200To400.51.root" Lumi="0.0"/>
+    <InputData Lumi="4580" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-20" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-20.45.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="32087.73" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT400To600" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT400To600.52.root" Lumi="0.0"/>
+    <InputData Lumi="476033" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-200.46.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="257120.9" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT600To800" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT600To800.53.root" Lumi="0.0"/>
+    <InputData Lumi="1666305" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-300" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-300.47.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="247357.8" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT800To1200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT800To1200.54.root" Lumi="0.0"/>
+    <InputData Lumi="16434" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-50.48.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="158373.4" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT1200To2500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT1200To2500.55.root" Lumi="0.0"/>
+    <InputData Lumi="10120000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-500.49.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6769850.0" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT2500ToInf" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT2500ToInf.56.root" Lumi="0.0"/>
+    <InputData Lumi="57030000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-500_Mphi-500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-500_Mphi-500.50.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="8358.5" NEventsMax="-1" Type="MC" Version="MC_WW" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WW.57.root" Lumi="0.0"/>
+    <InputData Lumi="509300" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-200.51.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="20982.7" NEventsMax="-1" Type="MC" Version="MC_WZ" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WZ.58.root" Lumi="0.0"/>
+    <InputData Lumi="1670000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-300" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-300.52.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="60158.9" NEventsMax="-1" Type="MC" Version="MC_ZZ" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ZZ.59.root" Lumi="0.0"/>
+    <InputData Lumi="19120000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-50" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-50.53.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
     </InputData>
-  
+    <InputData Lumi="8371" NEventsMax="-1" Type="MC" Version="MC_WW" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WW.54.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="20762" NEventsMax="-1" Type="MC" Version="MC_WZ" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WZ.55.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="60336.7" NEventsMax="-1" Type="MC" Version="MC_ZZ" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_ZZ.56.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="1218575" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt1000toInf_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt1000toInf_MuEnrichedPt5.62.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="449.7005" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt170to300_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt170to300_MuEnrichedPt5.65.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="4950.336" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt300to470_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt300to470_MuEnrichedPt5.67.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="24328.77" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt470to600_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt470to600_MuEnrichedPt5.69.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="73285.66" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt600to800_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt600to800_MuEnrichedPt5.71.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="419776" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt800to1000_MuEnrichedPt5" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt800to1000_MuEnrichedPt5.72.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="116421" NEventsMax="-1" Type="MC" Version="MC_TT" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TT.74.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="50620" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-1000toInf" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-1000toInf.75.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="114709.7" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-700to1000" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-700to1000.76.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="61526.7" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu.77.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="6238.42" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-100To200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-100To200.78.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="158969" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-1200To2500" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-1200To2500.79.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="11997" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-200To400" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-200To400.80.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="6502508" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-2500ToInf" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-2500ToInf.81.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="29501" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-400To600" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-400To600.82.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="277219" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-600To800" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-600To800.83.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="236566" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-800To1200" Cacheable="False">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ttDMSelectionCycleMuon/RunII_25ns_v2_Loose/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-800To1200.84.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+    </InputData>
+
     <UserConfig>
       <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
       <Item Name="ElectronCollection" Value="slimmedElectronsUSER" />
@@ -226,13 +306,18 @@
       <Item Name="TauCollection" Value="slimmedTaus" />
       <Item Name="JetCollection" Value="slimmedJets" />
       <Item Name="GenJetCollection" Value="slimmedGenJets" />
-      <Item Name="METName" Value="slimmedMETs" />
-      <Item Name="TopJetCollection" Value="slimmedJetsAK8_CMSTopTag" />
+      <Item Name="METName" Value="slimmedMETsNoHF" />
+      <Item Name="TopJetCollection" Value="slimmedJetsAK8_SoftDrop" />
       <Item Name="GenParticleCollection" Value="GenParticles" />
       <Item Name="channel" Value="muon" />
       <Item Name="AnalysisModule" Value="ttDMPostSelectionModule" />
+
+      <Item Name="lumi_file" Value="../../common/data/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_NoBadBSRuns.root" />
+      <Item Name="dopvfilter" Value="true" />
+      <Item Name="pileup_directory_data" Value="../../common/data/MyDataPileupHistogram.root" />
+      <Item Name="pileup_directory_25ns" Value="../../common/data/Pileup.MC.TTbar.root" />
+
     </UserConfig>
 
   </Cycle>
 </JobConfiguration>
-  

--- a/config/ttDMSelection_MUON_FNAL.xml
+++ b/config/ttDMSelection_MUON_FNAL.xml
@@ -1,303 +1,429 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
+<!ENTITY TT SYSTEM "./ZprimePreSelection_TTSample.xml">
 ]>
 
 <JobConfiguration JobName="ttDMSelectionJob" OutputLevel="INFO">
   <Library Name="libSUHH2ttDMSemiLeptonic"/>
   <Package Name="SUHH2ttDMSemiLeptonic.par" />
   <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="./" PostFix="" TargetLumi="1" >
-    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-PromptReco-v3" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-PromptReco-v3.2.root" Lumi="0.0"/>
+    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-05Oct2015-v1" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-05Oct2015-v1.3.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="49360680.4" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-10to50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-10to50.3.root" Lumi="0.0"/>
+    <InputData Lumi="1.0" NEventsMax="-1" Type="DATA" Version="SingleMuon_Run2015D-PromptReco-v4" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.DATA.SingleMuon_Run2015D-PromptReco-v4.4.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="74961297.1" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-50.4.root" Lumi="0.0"/>
+    <InputData Lumi="48437390" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-10to50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-10to50.7.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="15302.42" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0100to0200" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0100to0200.1.root" Lumi="0.0"/>
+    <InputData Lumi="74669470" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M-50.8.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="18167.30" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0200to0400" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0200to0400.2.root" Lumi="0.0"/>
+    <InputData Lumi="19552.8" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0100to0200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0100to0200.9.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="154894.59" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0400to0600" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0400to0600.3.root" Lumi="0.0"/>
+    <InputData Lumi="22782.2" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0200to0400" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0200to0400.10.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="363191.59" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0600toINFT" Cacheable="True">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0600toINFT.4.root" Lumi="0.0"/>
+    <InputData Lumi="194244" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0400to0600" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0400to0600.11.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="291457.1" NEventsMax="-1" Type="MC" Version="MC_ST_s-channel_4f_leptonDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_s-channel_4f_leptonDecays.31.root" Lumi="0.0"/>
+    <InputData Lumi="451996" NEventsMax="-1" Type="MC" Version="MC_DYJetsToLL_M50_HT0600toINFT" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_DYJetsToLL_M50_HT0600toINFT.12.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6146790.4" NEventsMax="-1" Type="MC" Version="MC_ST_t-channel_4f_leptonDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_t-channel_4f_leptonDecays.32.root" Lumi="0.0"/>
+    <InputData Lumi="291220" NEventsMax="-1" Type="MC" Version="MC_ST_s-channel_4f_leptonDecays" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_ST_s-channel_4f_leptonDecays.13.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="27831.2" NEventsMax="-1" Type="MC" Version="MC_ST_tW_antitop_5f_inclusiveDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_tW_antitop_5f_inclusiveDecays.33.root" Lumi="0.0"/>
+    <InputData Lumi="18895860" NEventsMax="-1" Type="MC" Version="MC_ST_t-channel_4f_leptonDecays" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_ST_t-channel_4f_leptonDecays.14.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="27709.4" NEventsMax="-1" Type="MC" Version="MC_ST_tW_top_5f_inclusiveDecays" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ST_tW_top_5f_inclusiveDecays.34.root" Lumi="0.0"/>
+    <InputData Lumi="27966.9" NEventsMax="-1" Type="MC" Version="MC_STneg_tW_inc" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_STneg_tW_inc.15.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="113811.0" NEventsMax="-1" Type="MC" Version="MC_TTbar" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbar.37.root" Lumi="0.0"/>
+    <InputData Lumi="27966.3" NEventsMax="-1" Type="MC" Version="MC_STpos_tW_inc" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_STpos_tW_inc.16.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="49294.7" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-700to1000" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-700to1000.36.root" Lumi="0.0"/>
+    <InputData Lumi="45960000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1.17.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="112601.2" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-1000toInf" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-1000toInf.35.root" Lumi="0.0"/>
+    <InputData Lumi="45990000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-10" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-10.18.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="0.616" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-15to20_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-15to20_MuEnrichedPt5.9.root" Lumi="0.0"/>
+    <InputData Lumi="58360000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-100" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-100.19.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1.768" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-20to30_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-20to30_MuEnrichedPt5.13.root" Lumi="0.0"/>
+    <InputData Lumi="3815000000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1000.20.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="2.984" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-30to50_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-30to50_MuEnrichedPt5.17.root" Lumi="0.0"/>
+    <InputData Lumi="79160000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-200.21.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="11.52" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-50to80_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-50to80_MuEnrichedPt5.20.root" Lumi="0.0"/>
+    <InputData Lumi="48920000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-50.22.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="36.52" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-80to120_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-80to120_MuEnrichedPt5.24.root" Lumi="0.0"/>
+    <InputData Lumi="315300000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-500.23.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="159.5" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-120to170_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-120to170_MuEnrichedPt5.7.root" Lumi="0.0"/>
+    <InputData Lumi="505800000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-600" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-600.24.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="454.5" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-170to300_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-170to300_MuEnrichedPt5.11.root" Lumi="0.0"/>
+    <InputData Lumi="3186000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10.25.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="4893.1" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-300to470_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-300to470_MuEnrichedPt5.14.root" Lumi="0.0"/>
+    <InputData Lumi="250000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100.26.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="24346.6" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-470to600_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-470to600_MuEnrichedPt5.18.root" Lumi="0.0"/>
+    <InputData Lumi="163100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50.27.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="78855.4" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-600to800_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-600to800_MuEnrichedPt5.21.root" Lumi="0.0"/>
+    <InputData Lumi="151200000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-1000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-1000.28.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="420118.0" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-800to1000_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-800to1000_MuEnrichedPt5.22.root" Lumi="0.0"/>
+    <InputData Lumi="127300000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200.29.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1219588.2" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt-1000toInf_MuEnrichedPt5" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt-1000toInf_MuEnrichedPt5.5.root" Lumi="0.0"/>
+    <InputData Lumi="11220000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-500.30.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="45901773930" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-1" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-1.38.root" Lumi="0.0"/>
+    <InputData Lumi="112238" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10.31.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="57301200370" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-100.39.root" Lumi="0.0"/>
+    <InputData Lumi="260373" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100.32.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="77601515550" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_EFT_M-200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_EFT_M-200.40.root" Lumi="0.0"/>
+    <InputData Lumi="121100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-20" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-20.33.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="3250197" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-10.41.root" Lumi="0.0"/>
+    <InputData Lumi="553100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-200.34.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="250344.1" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-100.42.root" Lumi="0.0"/>
+    <InputData Lumi="1265000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300.35.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="163325.8" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-10_Mphi-50.43.root" Lumi="0.0"/>
+    <InputData Lumi="165200" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-50.36.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="127494310" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-150_Mphi-200.44.root" Lumi="0.0"/>
+    <InputData Lumi="9620000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-500.37.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="112382" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-10.45.root" Lumi="0.0"/>
+    <InputData Lumi="17890000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500.38.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="260709.1" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100.46.root" Lumi="0.0"/>
+    <InputData Lumi="588200" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-200.39.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1266911.4" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-1_Mphi-300.47.root" Lumi="0.0"/>
+    <InputData Lumi="1328000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300.40.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="17922176310" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-500_Mphi-500.48.root" Lumi="0.0"/>
+    <InputData Lumi="17260000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50.41.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1671503.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-300.49.root" Lumi="0.0"/>
+    <InputData Lumi="494100" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-10" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-10.42.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="19144916.2" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_pseudoscalar_Mchi-50_Mphi-50.50.root" Lumi="0.0"/>
+    <InputData Lumi="66290" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-100" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-100.43.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="494648.9" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-10" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-10.51.root" Lumi="0.0"/>
+    <InputData Lumi="16330" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-50.44.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="66370.5" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-100.52.root" Lumi="0.0"/>
+    <InputData Lumi="363800000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-200.45.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="16350.3" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-10_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-10_Mphi-50.53.root" Lumi="0.0"/>
+    <InputData Lumi="2262" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-10" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-10.46.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="158066801.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-1000" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-1000.54.root" Lumi="0.0"/>
+    <InputData Lumi="71210" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-100" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-100.47.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="12917746.5" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-150_Mphi-500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-150_Mphi-500.55.root" Lumi="0.0"/>
+    <InputData Lumi="152300000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-1000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-1000.48.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="71303.3" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-100" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-100.56.root" Lumi="0.0"/>
+    <InputData Lumi="4580" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-20" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-20.49.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="16457.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-50.57.root" Lumi="0.0"/>
+    <InputData Lumi="476033" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-200.50.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="1671503.6" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-300" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-300.58.root" Lumi="0.0"/>
+    <InputData Lumi="1666305" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-300" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-300.51.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="19144916.2" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-50" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-50.59.root" Lumi="0.0"/>
+    <InputData Lumi="16434" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-50.52.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="60501928.3" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu.60.root" Lumi="0.0"/>
+    <InputData Lumi="10120000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-1_Mphi-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-1_Mphi-500.53.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6099.987" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT100To200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT100To200.61.root" Lumi="0.0"/>
+    <InputData Lumi="57030000000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-500_Mphi-500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-500_Mphi-500.54.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="12010.68" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT200To400" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT200To400.62.root" Lumi="0.0"/>
+    <InputData Lumi="509300" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-200.55.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="32087.73" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT400To600" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT400To600.63.root" Lumi="0.0"/>
+    <InputData Lumi="1670000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-300" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-300.56.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="257120.9" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT600To800" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT600To800.64.root" Lumi="0.0"/>
+    <InputData Lumi="19120000" NEventsMax="-1" Type="MC" Version="MC_TTbarDMJets_scalar_Mchi-50_Mphi-50" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TTbarDMJets_scalar_Mchi-50_Mphi-50.57.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="247357.8" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT800To1200" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT800To1200.65.root" Lumi="0.0"/>
+    <InputData Lumi="8371" NEventsMax="-1" Type="MC" Version="MC_WW" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WW.58.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="158373.4" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT1200To2500" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT1200To2500.66.root" Lumi="0.0"/>
+    <InputData Lumi="20762" NEventsMax="-1" Type="MC" Version="MC_WZ" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WZ.59.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="6769850.0" NEventsMax="-1" Type="MC" Version="MC_WJets_LNu_HT2500ToInf" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WJets_LNu_HT2500ToInf.67.root" Lumi="0.0"/>
+    <InputData Lumi="60336.7" NEventsMax="-1" Type="MC" Version="MC_ZZ" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_ZZ.60.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="8358.5" NEventsMax="-1" Type="MC" Version="MC_WW" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WW.68.root" Lumi="0.0"/>
+    <InputData Lumi="4098.8" NEventsMax="-1" Type="MC" Version="MC_QCD_HT1000to1500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_HT1000to1500.61.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="20982.7" NEventsMax="-1" Type="MC" Version="MC_WZ" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_WZ.69.root" Lumi="0.0"/>
+    <InputData Lumi="32160.5" NEventsMax="-1" Type="MC" Version="MC_QCD_HT1500to2000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_HT1500to2000.62.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
-    <InputData Lumi="60158.9" NEventsMax="-1" Type="MC" Version="MC_ZZ" Cacheable="False">
-      <In FileName="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/uhh2.AnalysisModuleRunner.MC.MC_ZZ.70.root" Lumi="0.0"/>
+    <InputData Lumi="75514.0" NEventsMax="-1" Type="MC" Version="MC_QCD_HT2000toInf" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_HT2000toInf.63.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="610.3" NEventsMax="-1" Type="MC" Version="MC_QCD_HT500to700" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_HT500to700.64.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="2239.8" NEventsMax="-1" Type="MC" Version="MC_QCD_HT700to1000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_HT700to1000.65.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="1218575" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt1000toInf_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt1000toInf_MuEnrichedPt5.66.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="159.3254" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt120to170_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt120to170_MuEnrichedPt5.68.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="0.616799" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt15to20_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt15to20_MuEnrichedPt5.70.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="449.7005" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt170to300_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt170to300_MuEnrichedPt5.74.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="1.789896" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt20to30_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt20to30_MuEnrichedPt5.76.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="4950.336" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt300to470_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt300to470_MuEnrichedPt5.79.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="2.985318" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt30to50_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt30to50_MuEnrichedPt5.82.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="24328.77" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt470to600_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt470to600_MuEnrichedPt5.84.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="11.53085" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt50to80_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt50to80_MuEnrichedPt5.86.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="73285.66" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt600to800_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt600to800_MuEnrichedPt5.87.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="419776" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt800to1000_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt800to1000_MuEnrichedPt5.88.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="36.51028" NEventsMax="-1" Type="MC" Version="MC_QCD_Pt80to120_MuEnrichedPt5" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_QCD_Pt80to120_MuEnrichedPt5.90.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="116421" NEventsMax="-1" Type="MC" Version="MC_TT" Cacheable="True">
+      &TT;
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="50620" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-1000toInf" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-1000toInf.92.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="114709.7" NEventsMax="-1" Type="MC" Version="MC_TT_Mtt-700to1000" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_TT_Mtt-700to1000.93.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="61526.7" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu.94.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="6238.42" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-100To200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-100To200.95.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="158969" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-1200To2500" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-1200To2500.96.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="11997" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-200To400" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-200To400.97.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="6502508" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-2500ToInf" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-2500ToInf.98.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="29501" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-400To600" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-400To600.99.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="277219" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-600To800" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-600To800.100.root" Lumi="0.0"/>
+      <InputTree Name="AnalysisTree" />
+      <OutputTree Name="AnalysisTree" />
+    </InputData>
+    <InputData Lumi="236566" NEventsMax="-1" Type="MC" Version="MC_WJetsToLNu_HT-800To1200" Cacheable="True">
+      <In FileName="root://cmsxrootd.fnal.gov///store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v2/uhh2.AnalysisModuleRunner.MC.MC_WJetsToLNu_HT-800To1200.101.root" Lumi="0.0"/>
       <InputTree Name="AnalysisTree" />
       <OutputTree Name="AnalysisTree" />
     </InputData>
@@ -309,18 +435,18 @@
       <Item Name="TauCollection" Value="slimmedTaus" />
       <Item Name="JetCollection" Value="slimmedJets" />
       <Item Name="GenJetCollection" Value="slimmedGenJets" />
-      <Item Name="METName" Value="slimmedMETs" />
-      <Item Name="TopJetCollection" Value="slimmedJetsAK8_CMSTopTag" />
+      <Item Name="METName" Value="slimmedMETsNoHF" />
+      <Item Name="TopJetCollection" Value="slimmedJetsAK8_SoftDrop" />
       <Item Name="GenParticleCollection" Value="GenParticles" />
 
       <Item Name="channel" Value="muon" />
 
       <Item Name="dopvfilter" Value="true" />
       <Item Name="dometfilters" Value="true" />
-      <Item Name="lumi_file" Value="" />
+      <Item Name="lumi_file" Value="../../common/data/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_Silver_NoBadBSRuns.root" />
 
-      <Item Name="pileup_directory_data" Value="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/PileupFiles/MyDataPileupHistogram.root" />
-      <Item Name="pileup_directory_25ns" Value="/eos/uscms/store/user/drberry/ZprimePreSelectionCycle/13TeV/RunII_25ns_v1/PileupFiles/Pileup.MC.TTbar.root" />
+      <Item Name="pileup_directory_data" Value="../../common/data/MyDataPileupHistogram.root" />
+      <Item Name="pileup_directory_25ns" Value="../../common/data/Pileup.MC.TTbar.root" />
 
       <Item Name="AnalysisModule" Value="ttDMSelectionModule" />
     </UserConfig>

--- a/src/ttDMSelectionModule.cxx
+++ b/src/ttDMSelectionModule.cxx
@@ -135,7 +135,7 @@ ttDMSelectionModule::ttDMSelectionModule(Context & ctx){
 
   //// OBJ CLEANING
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDMedium(), PtEtaCut(45., 2.1))));
-  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_MVAnotrig_Spring15_25ns_loose, PtEtaCut(50., 2.5))));
+  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_MVAnotrig_Spring15_25ns_tight, PtEtaCut(50., 2.5))));
   if (is_mc) {
     jet_corrector.reset(new JetCorrector(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
     jetlepton_cleaner.reset(new JetLeptonCleaner(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_MC));

--- a/src/ttDMSelectionModule.cxx
+++ b/src/ttDMSelectionModule.cxx
@@ -137,13 +137,13 @@ ttDMSelectionModule::ttDMSelectionModule(Context & ctx){
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDMedium(), PtEtaCut(45., 2.1))));
   ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_MVAnotrig_Spring15_25ns_loose, PtEtaCut(50., 2.5))));
   if (is_mc) {
-    jet_corrector.reset(new JetCorrector(JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
-    jetlepton_cleaner.reset(new JetLeptonCleaner(JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
-    topjet_corrector.reset(new TopJetCorrector(JERFiles::Summer15_25ns_L123_AK8PFchs_MC));
+    jet_corrector.reset(new JetCorrector(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
+    jetlepton_cleaner.reset(new JetLeptonCleaner(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_MC));
+    topjet_corrector.reset(new TopJetCorrector(ctx, JERFiles::Summer15_25ns_L123_AK8PFchs_MC));
   } else {
-    jet_corrector.reset(new JetCorrector(JERFiles::Summer15_25ns_L123_AK4PFchs_DATA));
-    jetlepton_cleaner.reset(new JetLeptonCleaner(JERFiles::Summer15_25ns_L123_AK4PFchs_DATA));
-    topjet_corrector.reset(new TopJetCorrector(JERFiles::Summer15_25ns_L123_AK8PFchs_DATA));
+    jet_corrector.reset(new JetCorrector(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_DATA));
+    jetlepton_cleaner.reset(new JetLeptonCleaner(ctx, JERFiles::Summer15_25ns_L123_AK4PFchs_DATA));
+    topjet_corrector.reset(new TopJetCorrector(ctx, JERFiles::Summer15_25ns_L123_AK8PFchs_DATA));
   }
   jetER_smearer.reset(new JetResolutionSmearer(ctx));
   jetlepton_cleaner->set_drmax(.4);


### PR DESCRIPTION
This update switches to the 74X MiniAODv2 samples and adds lumi filtering and PU reweighting to the post-selection cycle.
